### PR TITLE
Fix sprintf redefinition on _MSC_VER >= 1900

### DIFF
--- a/CUnit/Headers/CUnit.h
+++ b/CUnit/Headers/CUnit.h
@@ -102,7 +102,9 @@
 #    define CU_EXPORT
 #  endif
 #  ifdef _MSC_VER
-#    define snprintf _snprintf
+#    if _MSC_VER < 1900
+#      define snprintf _snprintf
+#    endif
 #  endif
 #else
 #  define CU_EXPORT


### PR DESCRIPTION
Fix for _MSC_VER >= 1900:
C1189: #error:  Macro definition of snprintf conflicts with Standard Library function declaration